### PR TITLE
Lp.morele.net

### DIFF
--- a/PAF_newsletters.txt
+++ b/PAF_newsletters.txt
@@ -1925,7 +1925,7 @@ zyciepabianic.pl###widget-newsletter
 ~pl###box_newsletter:lang(pl)
 ~pl###menu_newsletter:lang(pl)
 ~pl###newsletter:not(.modal):lang(pl)
-~pl,~pl.tommy.com##.newsletter:not(#popup_newsletter):not(.in-line):not(.curvyIgnore):not(.popup):not(input):lang(pl)
+~lp.morele.net,~pl,~pl.tommy.com##.newsletter:not(#popup_newsletter):not(.in-line):not(.curvyIgnore):not(.popup):not(input):lang(pl)
 pl##.ModulNewsletter
 pl##.boxNewsletter
 pl##.fnls

--- a/PAF_newsletters.txt
+++ b/PAF_newsletters.txt
@@ -4,8 +4,8 @@
 ! Polish Annoyance Filters - Newsletters
 ! Codename: Newsletters
 ! Description: Filtry ukrywające i blokujące newslettery (bez pop-upów).
-! Last modified: Thu, 23 Jun 2022, 17:30 UTC+02
-! Version: 2022.6.23.0
+! Last modified: Thu, 24 Jun 2022, 16:16 UTC+02
+! Version: 2022.6.24.0
 ! Expires: 3 days
 ! Najnowsza wersja zawsze na: https://github.com/PolishFiltersTeam/PolishAnnoyanceFilters
 ! Zgłoszenia:
@@ -13,7 +13,7 @@
 !   GitHub => https://github.com/PolishFiltersTeam/PolishAnnoyanceFilters/issues
 ! License: CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0/deed)
 ! Maintainer: Filters Heroes
-! Aktualizacja: czw, 23 cze 2022, 17:30 UTC+02
+! Aktualizacja: czw, 24 cze 2022, 16:16 UTC+02
 !
 !
 !


### PR DESCRIPTION
Przy obecnych filtrach [https://lp.morele.net/newsletter/](https://lp.morele.net/newsletter/) ukrywa oferty dla subskrybentów newslettera w momencie załadowania filtrów kosmetycznych. 

Dodanie `lp.morele.net` do wyjątków reguły `##.newsletter:not(#popup_newsletter):not(.in-line):not(.curvyIgnore):not(.popup):not(input):lang(pl)` pozwala na prawidłowe wyświetlenie strony. 